### PR TITLE
Let callbacks resolve against something other than the controller

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,36 @@
+# Line endings
+#
+# Checked out with LF everywhere, whatever core.autocrlf says locally.
+#
+# Without this, a Windows clone with core.autocrlf=true gets CRLF source, and
+# fifteen tests fail that pass everywhere else. They compare helper output
+# against a literal multi-line string written in the test file: the helpers
+# build their output from "\n" escapes, so they always emit LF, while the
+# expected value picks up whatever the file on disk uses. CRLF checkout, CRLF
+# expectation, LF actual, failure - in Form_helper_test, Html_helper_test and
+# Calendar_test.
+#
+# This only affects what lands in the working tree. Repository content is
+# unchanged, and PHP does not care either way, so nothing downstream breaks.
+* text=auto eol=lf
+
+# Windows-only files keep their native endings
+*.bat text eol=crlf
+
+# Binaries git should not touch at all
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.gz binary
+
 # This file tells which files and directories should be ignored and
 # NOT downloaded when using composer to pull down a project with
 # the --prefer-dist option selected. Used to remove development

--- a/system/libraries/Form_validation.php
+++ b/system/libraries/Form_validation.php
@@ -57,6 +57,23 @@ class CI_Form_validation {
 	protected $CI;
 
 	/**
+	 * Object that callback_ rules are resolved against.
+	 *
+	 * NULL means the CodeIgniter instance, which is the historic behaviour and
+	 * is correct when callbacks live on the controller.
+	 *
+	 * This exists because $CI was doing two unrelated jobs: it is the handle
+	 * for core services (lang, uri, router, input) AND it was the only place a
+	 * callback could be looked up. Code that wanted callbacks somewhere other
+	 * than the controller had to overwrite $CI outright, which quietly broke
+	 * the services and made the callback target depend on whoever assigned
+	 * last. Setting this instead leaves $CI alone.
+	 *
+	 * @var object|null
+	 */
+	protected $_callback_object = NULL;
+
+	/**
 	 * Validation data for the current form submission
 	 *
 	 * @var array
@@ -148,6 +165,46 @@ class CI_Form_validation {
 		$this->CI->load->helper('form');
 
 		log_message('info', 'Form Validation Class Initialized');
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Set Callback Object
+	 *
+	 * Tells the validator where to look for callback_ rules. Without this the
+	 * only way to run callbacks on a model, a service or any other collaborator
+	 * is to overwrite $CI, which also hands it the job of supplying lang, uri,
+	 * router and input.
+	 *
+	 * The library is shared for the whole request, so set this immediately
+	 * before run() rather than once in a constructor - otherwise whoever
+	 * constructed last owns every callback lookup that follows.
+	 *
+	 * Pass NULL to go back to the CodeIgniter instance.
+	 *
+	 * @param	object|null	$object
+	 * @return	CI_Form_validation
+	 */
+	public function set_callback_object($object = NULL)
+	{
+		$this->_callback_object = is_object($object) ? $object : NULL;
+		return $this;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Callback Object
+	 *
+	 * Where callback_ rules are resolved, defaulting to the CodeIgniter
+	 * instance so existing controllers are unaffected.
+	 *
+	 * @return	object
+	 */
+	public function callback_object()
+	{
+		return isset($this->_callback_object) ? $this->_callback_object : $this->CI;
 	}
 
 	// --------------------------------------------------------------------
@@ -713,7 +770,9 @@ class CI_Form_validation {
 			{
 				if ($callback)
 				{
-					if ( ! method_exists($this->CI, $rule))
+					$object = $this->callback_object();
+
+					if ( ! method_exists($object, $rule))
 					{
 						log_message('debug', 'Unable to find callback validation rule: '.$rule);
 						$result = FALSE;
@@ -721,7 +780,7 @@ class CI_Form_validation {
 					else
 					{
 						// Run the function and grab the result
-						$result = $this->CI->$rule($postdata, $param);
+						$result = $object->$rule($postdata, $param);
 					}
 				}
 				else

--- a/tests/codeigniter/libraries/Form_validation_test.php
+++ b/tests/codeigniter/libraries/Form_validation_test.php
@@ -604,6 +604,79 @@ class Form_validation_test extends CI_TestCase {
 		$this->assertEquals('?&gt;', $this->form_validation->encode_php_tags('?>'));
 	}
 
+	// --------------------------------------------------------------------
+	// set_callback_object()
+	// --------------------------------------------------------------------
+
+	public function test_callback_object_defaults_to_the_ci_instance()
+	{
+		// The historic behaviour: callbacks live on the controller
+		$this->assertSame(
+			$this->ci_instance(),
+			$this->form_validation->callback_object()
+		);
+	}
+
+	public function test_set_callback_object_redirects_callback_lookup()
+	{
+		$this->form_validation->set_callback_object(new Form_validation_test_callbacks());
+
+		$this->assertTrue($this->run_rules(
+			array(array('field' => 'foo', 'label' => 'Foo', 'rules' => 'callback_is_the_word_ok')),
+			array('foo' => 'ok')
+		));
+
+		$this->assertFalse($this->run_rules(
+			array(array('field' => 'foo', 'label' => 'Foo', 'rules' => 'callback_is_the_word_ok')),
+			array('foo' => 'nope')
+		));
+	}
+
+	public function test_set_callback_object_leaves_the_ci_reference_alone()
+	{
+		// The point of the whole change. Overwriting $CI to move callbacks
+		// also took lang, uri, router and input with it.
+		$before = $this->ci_instance();
+
+		$this->form_validation->set_callback_object(new Form_validation_test_callbacks());
+
+		$this->assertSame($before, $this->ci_instance());
+		$this->assertNotSame($this->ci_instance(), $this->form_validation->callback_object());
+	}
+
+	public function test_set_callback_object_null_restores_the_ci_instance()
+	{
+		$this->form_validation->set_callback_object(new Form_validation_test_callbacks());
+		$this->form_validation->set_callback_object(NULL);
+
+		$this->assertSame($this->ci_instance(), $this->form_validation->callback_object());
+	}
+
+	public function test_set_callback_object_ignores_a_non_object()
+	{
+		$this->form_validation->set_callback_object('not an object');
+
+		$this->assertSame($this->ci_instance(), $this->form_validation->callback_object());
+	}
+
+	public function test_set_callback_object_is_chainable()
+	{
+		$this->assertSame(
+			$this->form_validation,
+			$this->form_validation->set_callback_object(new Form_validation_test_callbacks())
+		);
+	}
+
+	public function test_a_missing_callback_still_fails_rather_than_erroring()
+	{
+		$this->form_validation->set_callback_object(new Form_validation_test_callbacks());
+
+		$this->assertFalse($this->run_rules(
+			array(array('field' => 'foo', 'label' => 'Foo', 'rules' => 'callback_no_such_method')),
+			array('foo' => 'ok')
+		));
+	}
+
 	/**
 	 * Run rules
 	 *
@@ -625,5 +698,17 @@ class Form_validation_test extends CI_TestCase {
 		$_POST = array();
 
 		return $valid;
+	}
+}
+
+/**
+ * A collaborator that is not the controller, which is the whole point of
+ * set_callback_object().
+ */
+class Form_validation_test_callbacks {
+
+	public function is_the_word_ok($str)
+	{
+		return $str === 'ok';
 	}
 }


### PR DESCRIPTION
Two independent changes, both additive.

## 1. Separate the callback target from the `$CI` reference

`CI_Form_validation::$CI` was doing two unrelated jobs:

- the handle for `lang`, `uri`, `router` and `input`
- the **only** place a `callback_` rule could be looked up

So code that wanted callbacks on anything but the controller — a model, a
service — had to overwrite `$CI` outright. That also handed away the core
services, and made the callback target depend on whoever assigned last.

The library is shared for the whole request and the assignment usually happens
in a constructor, so loading two such objects left the first one's callbacks
resolving to `Unable to find callback validation rule`. The rule never ran and
the field failed with:

    Unable to access an error message corresponding to your field name X.

which reads like a missing language line, not a missing callback. That is a
long way from the cause, and it is why this took a while to find.

### What changed

A separate `$_callback_object`, consulted only where callbacks are resolved:

```php
$this->form_validation->set_callback_object($model)->run();
$this->form_validation->callback_object();   // read it back
$this->form_validation->set_callback_object(NULL);  // back to the CI instance
```

`$CI` is left alone, so the services keep working.

### Backward compatibility

`$_callback_object` defaults to `NULL`, which means the CodeIgniter instance —
the historic behaviour. **No existing caller has to change and none behaves
differently.** The only touched call site is the `method_exists()` / invoke
pair inside `_execute()`, which now asks `callback_object()` instead of reading
`$this->CI` directly.

Because the library is request-scoped, the docblock tells callers to set it
immediately before `run()` rather than once in a constructor — otherwise
whoever constructed last owns every lookup that follows, which is the original
bug wearing a different hat.

### Tests

Seven new tests in `Form_validation_test`, covering: the default is the CI
instance; a set object receives the callback; `$CI` is untouched by setting it;
`NULL` restores the default; a non-object is ignored; the setter is chainable;
and a genuinely missing callback still fails cleanly rather than erroring.

## 2. `.gitattributes`: check out with LF

Fifteen tests fail in a Windows clone with `core.autocrlf=true` and pass
everywhere else — thirteen in `Form_helper_test`, one in `Html_helper_test`,
one in `Calendar_test`.

They are **not** PHP-version failures, which is what they look like at first.
Each compares helper output against a literal multi-line string written in the
test file. The helpers build output from `"\n"` escapes so they always emit LF,
while the expected value picks up whatever the file on disk uses. CRLF
checkout, CRLF expectation, LF actual, failure.

`.gitattributes` only carried `export-ignore` rules, so nothing told git how to
treat line endings and `core.autocrlf` won by default. Now `* text=auto eol=lf`,
plus `*.bat text eol=crlf` and binary rules.

**Repository content is unchanged.** `git add --renormalize` touched no file but
`.gitattributes` itself, confirming the blobs were already LF and only the
checkout differed. This affects the working tree only, and PHP does not care
either way.

## Verification

Full suite, PHP 8.5:

| | Tests | Assertions |
|---|---|---|
| `develop` | 364 | 1170 |
| this branch | **371** | **1179** |

All passing. The 54 PHPUnit deprecations and 33 skips are pre-existing on
`develop` and unchanged here.
